### PR TITLE
chore: add pre push hook to verify build is checked in

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn build && git diff --exit-code dist
+

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "packageManager": "yarn@3.2.3",
   "scripts": {
+    "prepare": "husky install",
     "test": "jest .",
     "lint": "yarn lint:actions && yarn lint:cli",
     "lint:actions": "eslint src",
@@ -39,6 +40,7 @@
     "@vercel/ncc": "^0.34.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.7.1",
+    "husky": "^8.0.3",
     "jest": "^29.2.1",
     "jest-extended": "^3.0.2",
     "jest-when": "^3.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,6 +709,7 @@ __metadata:
     eslint: ^7.32.0
     eslint-import-resolver-typescript: ^2.7.1
     get-stream: ^6.0.1
+    husky: ^8.0.3
     jest: ^29.2.1
     jest-extended: ^3.0.2
     jest-when: ^3.5.2
@@ -3857,6 +3858,15 @@ __metadata:
   dependencies:
     ms: ^2.0.0
   checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"husky@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "husky@npm:8.0.3"
+  bin:
+    husky: lib/bin.js
+  checksum: 837bc7e4413e58c1f2946d38fb050f5d7324c6f16b0fd66411ffce5703b294bd21429e8ba58711cd331951ee86ed529c5be4f76805959ff668a337dbfa82a1b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Add a pre-push hook to verify build is checked in (same as we have it in the auto-audit repo)

## Testplan
- `yarn prepare`
- Add a console.log statement somewhere under `src` and commit
- Try to push => should abort