### PR TITLE
chore: bump deps to fix security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "conventional-changelog-core": "^4.2.4",
     "get-stream": "^6.0.1"
+  },
+  "resolutions": {
+    "xml2js": "^0.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,7 +689,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.23.2":
+"@babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.19.4, @babel/traverse@npm:^7.19.6, @babel/traverse@npm:^7.7.2":
   version: 7.24.1
   resolution: "@babel/traverse@npm:7.24.1"
   dependencies:
@@ -4649,7 +4649,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.1.1":
+"http-cache-semantics@npm:^4.1.0":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
   checksum: 83ac0bc60b17a3a36f9953e7be55e5c8f41acc61b22583060e8dedc9dd5e3607c823a88d0926f9150e571f90946835c7fe150732801010845c72cd8bbff1a236
@@ -4803,7 +4803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip@npm:^2.0.1":
+"ip@npm:^2.0.0":
   version: 2.0.1
   resolution: "ip@npm:2.0.1"
   checksum: d765c9fd212b8a99023a4cde6a558a054c298d640fec1020567494d257afd78ca77e37126b1a3ef0e053646ced79a816bf50621d38d5e768cdde0431fa3b0d35
@@ -5769,7 +5769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.2":
+"json5@npm:^2.2.1":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -7671,7 +7671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tough-cookie@npm:^4.1.3":
+"tough-cookie@npm:^4.0.0":
   version: 4.1.3
   resolution: "tough-cookie@npm:4.1.3"
   dependencies:


### PR DESCRIPTION
resolves 
https://github.com/ExodusMovement/lerna-release-action/security/dependabot/2
https://github.com/ExodusMovement/lerna-release-action/security/dependabot/3
https://github.com/ExodusMovement/lerna-release-action/security/dependabot/4
https://github.com/ExodusMovement/lerna-release-action/security/dependabot/5
https://github.com/ExodusMovement/lerna-release-action/security/dependabot/10
https://github.com/ExodusMovement/lerna-release-action/security/dependabot/12

## Test Plan

to repro the lockfile changes, go to master, apply this diff and run yarn:
```diff
diff --git a/package.json b/package.json
index c1e7f0d..b5c89c7 100644
--- a/package.json
+++ b/package.json
@@ -61,5 +61,14 @@
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "conventional-changelog-core": "^4.2.4",
     "get-stream": "^6.0.1"
+  },
+  "resolutions": {
+    "@babel/traverse": "^7.23.2",
+    "http-cache-semantics": "^4.1.1",
+    "ts-jest/json5": "^2.2.2",
+    "@babel/core/json5": "^2.2.2",
+    "ip": "^2.0.1",
+    "@azure/core-http/tough-cookie": "^4.1.3",
+    "xml2js": "^0.5.0"
   }
 }


```