### PR TITLE
chore: bump @azure/ms-rest-js to get rid of old tough-cookie

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5766,14 +5766,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "json5@npm:1.0.1"
+"json5@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "json5@npm:1.0.2"
   dependencies:
     minimist: ^1.2.0
   bin:
     json5: lib/cli.js
-  checksum: e76ea23dbb8fc1348c143da628134a98adf4c5a4e8ea2adaa74a80c455fc2cdf0e2e13e6398ef819bfe92306b610ebb2002668ed9fc1af386d593691ef346fc3
+  checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
resolves

https://github.com/ExodusMovement/lerna-release-action/security/dependabot/2
https://github.com/ExodusMovement/lerna-release-action/security/dependabot/5