### PR TITLE
chore: don't declare dist as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-dist/** binary
 dist/** linguist-generated


### PR DESCRIPTION
There's a bug in git `2.46.x` preventing `git diff --exit-code` or `git diff --quiet` exiting with a non-zero exit code when there is a diff in a file declared as binary in `.gitattributes`. This will effectively disable our CI check to make sure that the action has been built and committed. 