### PR TITLE
feat(cli): add --list-unreleased

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -15,4 +15,47 @@ lerna-release-action modules/batcave,libraries/wayne-manor
 lerna-release-action
 # using interactive prompt with static versioning
 lerna-release-action -vs minor
+# release everything with unreleased feat/fix/perf/breaking changes
+lerna-release-action $(lerna-release-action --list-unreleased)
 ```
+
+`--list-unreleased` prints, as a comma-separated list, every non-private
+package that has a releasing change (`feat`/`fix`/`perf`/breaking) since its
+latest release tag. Packages whose only changes are
+`chore`/`build`/`docs`/`ci`/`test`/`refactor`/`style` (not even a patch) are
+omitted, as are packages already up to date; never-released packages are
+always included. Only the list is written to stdout, so it composes directly
+into a release run as shown above.
+
+The detection is content-anchored to resist messy tag history:
+
+1. **Baseline** = the `<name>@<version>` tag at or below the package's current
+   package.json version (ignores higher tags left by an unrelated package that
+   once shared the name).
+2. **Gate** on the actual `baseline..HEAD` diff for the directory — no content
+   change means up to date, regardless of what commit ancestry suggests.
+3. **Attribute** only the surviving changed lines: blame them to the PR that
+   produced them, then fetch that PR's retained `refs/pull/<n>/head` and ask
+   its pre-squash commits (the same per-commit attribution `version-dispatch`
+   uses) whether they actually release this package. This rejects both already
+   released commits leaking through non-linear history and `feat`-titled sweeps
+   whose real per-package change was a chore.
+
+This requires network access to `origin` (one ref fetch per candidate PR) and
+is meant to run on an up-to-date default branch.
+
+It uses the same per-commit attribution as `version-dispatch` but **does not
+honor `skip-release`**: that label gates version-dispatch's automatic release
+on merge, not whether a change is unreleased. A deliberate "release the
+backlog" sweep should surface skip-released changes too — you decide what to
+ship at the confirmation prompt.
+
+### Limitation
+
+The baseline is only as trustworthy as the release tags. In a repo whose tags
+sit on linear, per-package release commits this is reliable. In a repo with
+non-linear history where a tag commit's tree does **not** contain the package's
+released content (e.g. batch-release commits that tagged many packages at
+once), the `baseline..HEAD` diff can include already-released content, so that
+package may be reported even though it is up to date. Treat the output as
+release **candidates** to review, not a list to publish unattended.

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -13,6 +13,7 @@ import {
   validateAllowedStrategies,
 } from './action/version/strategy'
 import { version } from './local'
+import listUnreleased from './list-unreleased'
 import logger from './utils/logger'
 import { spawnSync } from './utils/process'
 
@@ -27,6 +28,10 @@ program
   )
   .option('-l, --local', 'Allows running the version workflow locally in case GH has issues')
   .option(
+    '--list-unreleased',
+    'Print packages with unreleased feat/fix/perf/breaking changes as a comma-separated list, then exit. Compose with: release $(release --list-unreleased)'
+  )
+  .option(
     '--github-token <token>',
     'Required for local versioning when token is not stored in ~/.config/gh/hosts.yml'
   )
@@ -34,7 +39,16 @@ program
 async function main() {
   program.parse()
 
-  const { versionStrategy, local } = program.opts<ProgramOpts>()
+  const { versionStrategy, local, listUnreleased: listUnreleasedFlag } = program.opts<ProgramOpts>()
+
+  if (listUnreleasedFlag) {
+    const packages = await listUnreleased()
+    packages.sort(byBasenameAsc)
+    // Only the CSV goes to stdout so `$(release --list-unreleased)` stays clean.
+    process.stdout.write(`${packages.join(',')}\n`)
+    return
+  }
+
   assertStrategy(versionStrategy)
 
   const [packagesCsv] = program.args

--- a/cli/src/list-unreleased.spec.ts
+++ b/cli/src/list-unreleased.spec.ts
@@ -1,0 +1,119 @@
+import { baselineTag, parsePrNumber, aggregateBumps } from './list-unreleased'
+
+describe('baselineTag', () => {
+  test('picks the highest tag at or below the package.json version, ignoring higher unrelated-lineage tags (guards the timer bug)', () => {
+    // package is at 1.2.2; an old same-named package reached 4.0.2 — must not anchor there.
+    expect(
+      baselineTag('@x/timer', '1.2.2', [
+        '@x/timer@1.2.0',
+        '@x/timer@1.2.2',
+        '@x/timer@3.4.3',
+        '@x/timer@4.0.2',
+      ])
+    ).toBe('@x/timer@1.2.2')
+  })
+
+  test('falls back to the highest tag below the version when the exact one is missing (bumped, not yet tagged)', () => {
+    expect(baselineTag('@x/p', '1.3.0', ['@x/p@1.2.0', '@x/p@1.2.2'])).toBe('@x/p@1.2.2')
+  })
+
+  test('orders prereleases within their cycle', () => {
+    expect(
+      baselineTag('@x/h', '5.0.0-rc.10', ['@x/h@5.0.0-rc.9', '@x/h@5.0.0-rc.10', '@x/h@4.0.0'])
+    ).toBe('@x/h@5.0.0-rc.10')
+  })
+
+  test('ignores non-semver tags', () => {
+    expect(baselineTag('@x/feat', '1.2.0', ['@x/feat@nightly', '@x/feat@1.2.0'])).toBe(
+      '@x/feat@1.2.0'
+    )
+  })
+
+  test('returns null when nothing was released at or below the version', () => {
+    expect(baselineTag('@x/new', '1.0.0', ['@x/new@2.0.0'])).toBeNull()
+    expect(baselineTag('@x/new', '1.0.0', ['@y/other@1.0.0'])).toBeNull()
+  })
+
+  test('does not match a different package sharing a name prefix', () => {
+    expect(baselineTag('@x/foo', '1.0.0', ['@x/foobar@1.0.0'])).toBeNull()
+  })
+})
+
+describe('parsePrNumber', () => {
+  test('reads the trailing (#N) GitHub appends to a squash subject', () => {
+    expect(parsePrNumber('feat(x): thing (#17280)')).toBe(17_280)
+  })
+
+  test('null when there is no PR ref', () => {
+    expect(parsePrNumber('feat: a plain commit')).toBeNull()
+  })
+
+  test('only matches at the end, not a mid-message reference', () => {
+    expect(parsePrNumber('fix: follow-up to (#5) regression')).toBeNull()
+  })
+})
+
+describe('aggregateBumps', () => {
+  // Mirrors the #17280 case: a feat commit touches only the plugin; the
+  // config-churn commit that touches a leaf lib is a chore → lib excluded.
+  const packagePaths = {
+    '@x/plugin': 'lint/plugin',
+    '@x/lib': 'libraries/lib',
+  }
+
+  test('attributes per commit by touched files, not PR-wide', () => {
+    const bumps = aggregateBumps(
+      [
+        { sha: 'a', message: 'feat: add rule', files: ['lint/plugin/index.js'] },
+        { sha: 'b', message: 'chore: churn config', files: ['libraries/lib/.eslintrc'] },
+      ],
+      packagePaths,
+      'feat: port rules (#17280)'
+    )
+    expect(bumps).toEqual({ '@x/plugin': 'minor' })
+  })
+
+  test('takes the highest bump across a package’s commits', () => {
+    const bumps = aggregateBumps(
+      [
+        { sha: 'a', message: 'fix: nit', files: ['lint/plugin/a.js'] },
+        { sha: 'b', message: 'feat!: breaking', files: ['lint/plugin/b.js'] },
+      ],
+      packagePaths,
+      'feat: x (#1)'
+    )
+    expect(bumps).toEqual({ '@x/plugin': 'major' })
+  })
+
+  test('ignores releasing commits that touch no workspace files', () => {
+    expect(
+      aggregateBumps(
+        [{ sha: 'a', message: 'feat: ci', files: ['.github/x.yml'] }],
+        packagePaths,
+        'feat: x (#1)'
+      )
+    ).toEqual({})
+  })
+
+  test('falls back to the PR title when no individual commit is releasing', () => {
+    const bumps = aggregateBumps(
+      [
+        { sha: 'a', message: 'wip', files: ['lint/plugin/a.js'] },
+        { sha: 'b', message: 'address review', files: ['libraries/lib/b.js'] },
+      ],
+      packagePaths,
+      'feat: shipped via non-conventional commits (#2)'
+    )
+    expect(bumps).toEqual({ '@x/plugin': 'minor', '@x/lib': 'minor' })
+  })
+
+  test('no fallback when the PR title is itself non-releasing', () => {
+    expect(
+      aggregateBumps(
+        [{ sha: 'a', message: 'wip', files: ['lint/plugin/a.js'] }],
+        packagePaths,
+        'chore: cleanup (#3)'
+      )
+    ).toEqual({})
+  })
+})

--- a/cli/src/list-unreleased.ts
+++ b/cli/src/list-unreleased.ts
@@ -1,0 +1,284 @@
+import { readFileSync } from 'node:fs'
+import * as path from 'node:path'
+import * as semver from 'semver'
+import { getPackagePaths } from '@exodus/lerna-utils'
+import { spawnSync } from './utils/process'
+import { filesToPackages } from './action/version-dispatch/files-to-packages'
+import { Bump, BUMP_NONE, bumpFromMessage, maxBump } from './action/version-dispatch/bumps'
+
+type Pkg = { dir: string; name: string; version: string; private?: boolean }
+type CommitWithFiles = { sha: string; message: string; files: string[] }
+
+const readPkg = (dir: string): Pkg => ({
+  dir,
+  ...JSON.parse(readFileSync(path.join(dir, 'package.json'), 'utf8')),
+})
+const git = (...args: string[]): string => spawnSync('git', args)
+const firstLine = (message: string): string => message.split('\n', 1)[0]!.trim()
+
+const PR_REF = /\(#(\d+)\)\s*$/
+export const parsePrNumber = (subject: string): number | null => {
+  const match = PR_REF.exec(subject.trim())
+  return match ? Number(match[1]) : null
+}
+
+/**
+ * Baseline = the highest `<name>@<version>` tag whose version is `<=` the
+ * package's current package.json version. Anchoring at-or-below the working
+ * version (a) ties the diff to THIS package's release lineage, ignoring higher
+ * tags left behind by an unrelated package that once shared the name, and
+ * (b) tolerates a version bumped but not yet tagged. `null` = never released.
+ * Exported for tests.
+ */
+export const baselineTag = (name: string, version: string, tags: string[]): string | null => {
+  const prefix = `${name}@`
+  const versions = tags
+    .filter((tag) => tag.startsWith(prefix))
+    .map((tag) => tag.slice(prefix.length))
+    .filter((candidate) => semver.valid(candidate) && semver.lte(candidate, version))
+  if (versions.length === 0) return null
+  return `${prefix}${semver.rsort(versions)[0]}`
+}
+
+/**
+ * Faithful, log-free port of version-dispatch's `aggregateBumps`: per-commit
+ * file attribution with a PR-title fallback when no individual commit yields a
+ * bump. ponytail: kept in sync by hand; extract a shared pure copy upstream if
+ * the two ever need to move in lockstep. Exported for tests.
+ */
+export const aggregateBumps = (
+  commits: CommitWithFiles[],
+  packagePaths: Record<string, string>,
+  prTitle: string
+): Record<string, Bump> => {
+  const bumps: Record<string, Bump> = {}
+  const touchedAcrossPr = new Set<string>()
+
+  for (const commit of commits) {
+    const bump = bumpFromMessage(commit.message)
+    const packages = filesToPackages(commit.files, packagePaths)
+    for (const name of packages) touchedAcrossPr.add(name)
+    if (bump === BUMP_NONE || packages.size === 0) continue
+    for (const name of packages) bumps[name] = maxBump(bumps[name] ?? BUMP_NONE, bump)
+  }
+
+  if (Object.keys(bumps).length > 0) return bumps
+
+  const titleBump = bumpFromMessage(prTitle)
+  if (titleBump !== BUMP_NONE && touchedAcrossPr.size > 0) {
+    return Object.fromEntries([...touchedAcrossPr].map((name) => [name, titleBump]))
+  }
+
+  return {}
+}
+
+// GitHub retains a merged PR's pre-squash commits at refs/pull/<n>/head even
+// after the branch is deleted. Fetch them all into refs/prs/<n> in one round
+// trip. ponytail: single batched fetch; chunk the refspecs for huge backlogs.
+const fetchPrRefs = (prs: number[]): void => {
+  if (prs.length === 0) return
+  spawnSync('git', [
+    'fetch',
+    '--quiet',
+    'origin',
+    ...prs.map((pr) => `+refs/pull/${pr}/head:refs/prs/${pr}`),
+  ])
+}
+
+const cleanupPrRefs = (prs: number[]): void => {
+  for (const pr of prs) {
+    try {
+      spawnSync('git', ['update-ref', '-d', `refs/prs/${pr}`])
+    } catch {
+      /* ref already gone */
+    }
+  }
+}
+
+// Per-package bumps a PR would produce, reconstructed from its retained head
+// ref — the same per-commit attribution version-dispatch uses. One `git log`
+// reads every commit's message and files at once. Requires the ref fetched.
+const bumpsForPr = (
+  pr: number,
+  packagePaths: Record<string, string>,
+  prTitle = '',
+  mainline = 'HEAD'
+): Record<string, Bump> => {
+  const ref = `refs/prs/${pr}`
+  const base = git('merge-base', ref, mainline).trim()
+  const raw = git('log', `${base}..${ref}`, '--format=%x00%H%x1e%B%x1e', '--name-only')
+  const commits: CommitWithFiles[] = raw
+    .split('\0')
+    .filter((record) => record.trim())
+    .map((record) => {
+      const [sha = '', message = '', files = ''] = record.split('\x1E')
+      return {
+        sha: sha.trim(),
+        message,
+        files: files
+          .split('\n')
+          .map((f) => f.trim())
+          .filter(Boolean),
+      }
+    })
+  return aggregateBumps(commits, packagePaths, prTitle)
+}
+
+// HEAD-side line numbers actually changed between `base` and HEAD within `dir`.
+const changedLines = (base: string, dir: string): Record<string, number[]> => {
+  const diff = git('diff', '--unified=0', '--no-color', base, 'HEAD', '--', dir)
+  const perFile: Record<string, number[]> = {}
+  let file: string | null = null
+  let headLine = 0
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++ ')) {
+      file = line.startsWith('+++ b/') ? line.slice(6) : null
+      if (file) perFile[file] = []
+      continue
+    }
+
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line)
+    if (hunk) {
+      headLine = Number(hunk[1])
+      continue
+    }
+
+    if (file && line.startsWith('+') && !line.startsWith('+++')) {
+      perFile[file]!.push(headLine)
+      headLine++
+    }
+  }
+
+  return perFile
+}
+
+// The commits that authored the given HEAD-side lines (blame attributes the
+// SURVIVING change to its real commit — so already-released content, unchanged
+// since the tag, never appears, and squashed commits map to their PR subject).
+const blameShas = (file: string, lines: number[]): string[] => {
+  if (lines.length === 0) return []
+  let out: string
+  try {
+    out = git('blame', '--line-porcelain', 'HEAD', '--', file)
+  } catch {
+    return []
+  }
+
+  const shaByLine = out
+    .split('\n')
+    .filter((l) => /^[\da-f]{40} /.test(l))
+    .map((l) => l.slice(0, 40))
+  const shas = lines.map((n) => shaByLine[n - 1]).filter((s): s is string => s !== undefined)
+  return [...new Set(shas)]
+}
+
+/**
+ * Repo-relative paths of every non-private package with a releasing change
+ * (feat/fix/perf/breaking) since its last release that is still present on
+ * HEAD. The pipeline is content-anchored end to end so hydra's messy tag
+ * history can't inflate the result:
+ *
+ *  1. Baseline on the `<name>@<version>` tag at-or-below package.json version.
+ *  2. Gate on the actual `base..HEAD` content diff for the dir (no diff → up
+ *     to date, even if commit ancestry suggests otherwise).
+ *  3. Attribute only the SURVIVING changed lines, via blame, to the PR that
+ *     produced them — then ask that PR's pre-squash commits (its head ref)
+ *     whether they actually release THIS package. This rejects both already
+ *     released commits leaking through non-linear history and `feat`-titled
+ *     sweeps whose real per-package change was a chore.
+ *
+ * Never-released packages are always included. ponytail: blame + one head-ref
+ * fetch per candidate PR — run on an up-to-date default branch; heavy on a
+ * large backlog but this is a deliberate, occasional sweep.
+ */
+export default async function listUnreleased(): Promise<string[]> {
+  const paths = await getPackagePaths()
+  const packages = paths.map(readPkg)
+  const packagePaths = Object.fromEntries(packages.map((pkg) => [pkg.name, pkg.dir]))
+  const tags = git('tag').split('\n').filter(Boolean)
+
+  type Candidate = { pkg: Pkg; prs: Set<number>; direct: boolean; never: boolean }
+  const candidates: Candidate[] = []
+  const prTitles = new Map<number, string>()
+  const subjectCache = new Map<string, string>()
+  const subjectOf = (sha: string): string => {
+    let subject = subjectCache.get(sha)
+    if (subject === undefined) {
+      subject = firstLine(git('show', '-s', '--format=%s', sha))
+      subjectCache.set(sha, subject)
+    }
+
+    return subject
+  }
+
+  for (const pkg of packages) {
+    if (pkg.private) continue
+    const base = baselineTag(pkg.name, pkg.version, tags)
+    if (base === null) {
+      candidates.push({ pkg, prs: new Set(), direct: false, never: true })
+      continue
+    }
+
+    // Relocation/stale-tag guard: if the baseline tag's tree has no files at the
+    // package's current path, the package was moved (or the tag is bogus), so a
+    // `base..HEAD` diff would report the whole package as new. We can't trust the
+    // baseline — surface it for manual review instead of over-stating it.
+    if (!git('ls-tree', '-r', '--name-only', `${base}^{tree}`, '--', pkg.dir).trim()) {
+      process.stderr.write(
+        `skip ${pkg.name}: baseline ${base} has no files at ${pkg.dir} (relocated or stale tag) — verify manually\n`
+      )
+      continue
+    }
+
+    if (!git('diff', '--name-only', base, 'HEAD', '--', pkg.dir).trim()) continue // up to date
+
+    const shas = new Set<string>()
+    for (const [file, lines] of Object.entries(changedLines(base, pkg.dir))) {
+      for (const sha of blameShas(file, lines)) shas.add(sha)
+    }
+
+    const prs = new Set<number>()
+    let direct = false
+    for (const sha of shas) {
+      const subject = subjectOf(sha)
+      const pr = parsePrNumber(subject)
+      if (pr !== null) {
+        prs.add(pr)
+        if (!prTitles.has(pr)) prTitles.set(pr, subject)
+      } else if (bumpFromMessage(git('show', '-s', '--format=%B', sha)) !== BUMP_NONE) {
+        direct = true // non-squash / direct-to-master commit — its subject is real
+      }
+    }
+
+    candidates.push({ pkg, prs, direct, never: false })
+  }
+
+  const allPrs = [...new Set(candidates.flatMap((candidate) => [...candidate.prs]))]
+  const prBumps = new Map<number, Record<string, Bump>>()
+  if (allPrs.length > 0) {
+    fetchPrRefs(allPrs)
+    for (const pr of allPrs) {
+      try {
+        prBumps.set(pr, bumpsForPr(pr, packagePaths, prTitles.get(pr) ?? ''))
+      } catch {
+        // unfetchable ref → fall back to the squash subject's bump
+        prBumps.set(
+          pr,
+          bumpFromMessage(prTitles.get(pr) ?? '') === BUMP_NONE ? {} : { __fallback__: BUMP_NONE }
+        )
+      }
+    }
+
+    cleanupPrRefs(allPrs)
+  }
+
+  return candidates
+    .filter(({ pkg, prs, direct, never }) => {
+      if (never || direct) return true
+      return [...prs].some((pr) => {
+        const bumps = prBumps.get(pr) ?? {}
+        return '__fallback__' in bumps || pkg.name in bumps
+      })
+    })
+    .map(({ pkg }) => pkg.dir)
+}

--- a/cli/src/utils/types.d.ts
+++ b/cli/src/utils/types.d.ts
@@ -2,4 +2,5 @@ export type ProgramOpts = {
   versionStrategy: string
   githubToken?: string
   local: boolean
+  listUnreleased?: boolean
 }


### PR DESCRIPTION
> ⏸️ **Paused — read before reviewing.**
> This was built to drive a one-shot **backlog** release (`lerna-release-action $(lerna-release-action --list-unreleased)`). Validated against a large consumer monorepo: the tool reliably **selects** packages with unreleased changes (248/251 sound baselines), but the intended **use** doesn't hold up. A trial release was opened and closed because `lerna`'s changelog generation attributes a commit's `BREAKING CHANGE:` footer to **every package whose files it touched**, so replaying a year of cross-cutting history (e.g. a keychain rename, an eslint-config retire) leaks spurious "BREAKING CHANGES" into unrelated **patch**-bumped consumers — misleading published release notes. The normal **per-PR** release flow doesn't hit this (each release replays one PR), so the backlog should drain that way, not via one curated mass release.
>
> So the feature works and is correct as a **"what's outstanding" report**, but it is *not* the right tool to drive a mass release. Paused pending a decision on whether to merge it as a reporting aid. Details in the thread / commit history.

---

## What

Adds `--list-unreleased` to the CLI: prints, as a comma-separated list, every non-private package with a releasing change (`feat`/`fix`/`perf`/breaking) since its last release. `chore`/`build`/`docs`/`ci`/`test`/`refactor`/`style`-only packages and already-up-to-date packages are omitted; never-released packages are always included.

```bash
lerna-release-action $(lerna-release-action --list-unreleased)
```

## Why

Releasing the accumulated backlog otherwise means hand-picking packages, or accepting `lerna version --conventional-commits`, which over-includes (patch-bumps dependents, treats any commit since a stale tag as a change).

## How — content-anchored to resist messy tag history

1. **Baseline** = the `<name>@<version>` tag at or below the package's current package.json version (ignores higher tags left by an unrelated package that once shared the name).
2. **Gate** on the actual `baseline..HEAD` diff for the directory — no content change ⇒ up to date, regardless of commit ancestry.
3. **Attribute** only the *surviving* changed lines: blame → the PR that produced them → fetch that PR's `refs/pull/<n>/head` → ask its pre-squash commits (the same per-commit attribution `version-dispatch` uses) whether they release this package. Rejects already-released commits leaking through non-linear history and `feat`-titled sweeps whose real per-package change was a chore.

Requires network access to `origin`; run on an up-to-date default branch. **Does not honor `skip-release`** (that gates auto-release on merge, not whether a change shipped) — output is a superset of what version-dispatch auto-released; prune at the confirm prompt.

## Limitation

The baseline is only as trustworthy as the release tags. Where a tag commit's tree does **not** contain the package's released content (batch-release commits on non-linear history), the `baseline..HEAD` diff can include already-released content, so a package may be reported when it's actually up to date. **Treat the output as release candidates to review, not a list to publish unattended.**

## Testing

- Unit tests for `baselineTag` (semver ≤ version, ignores unrelated higher-lineage tags), `parsePrNumber`, `aggregateBumps`. Full suite green (213 tests).
- Per-commit attribution verified against real `version-dispatch` previews on two repo-wide `feat`-titled sweeps: reconstructed bumps match the action's posted preview exactly (only the genuinely-feat packages, not the config-churned leaves).
- End-to-end dispatch in `actions-playground`: https://github.com/ExodusMovement/actions-playground/actions/runs/28119220733
